### PR TITLE
Add `closeOnScrollThreshold` prop.  Also, emit `atScrollTop` event.

### DIFF
--- a/index.vue
+++ b/index.vue
@@ -103,10 +103,13 @@ export default
 
 			# When scrolling up always show
 			return true if @scrollingUp
-			return true if !@scrollingUp and @isDetached and (Math.abs(@scrollY - @scrollYOnScrollDownStart) < @closeOnScrollThreshold)
 
 			# When scrolling down and detached, wait closeOnScrollThreshold before
 			# hiding
+			scrollDistanceSinceReveal = Math.abs @scrollY - @scrollYOnScrollDownStart
+			return true if !@scrollingUp and @isDetached and
+				scrollDistanceSinceReveal < @closeOnScrollThreshold
+
 			# When at top, show.  Else hide.
 			return !@scrolledPast
 

--- a/index.vue
+++ b/index.vue
@@ -43,11 +43,19 @@ export default
 		# Pass in a scroll value, like if using smooth scroller
 		scroll: Number
 
+		# When the bar is detached and revealed, this is the distance you must
+		# scroll down to hide the bar.  Larger values help prevent the user from
+		# accidentally hiding the bar when interacting with subnavs.
+		closeOnScrollThreshold:
+			type: Number
+			default: 0
+
 	data: ->
 		scrollingUp: false
 		windowScroll: 0
 		isDetached: false
 		disableTopTween: false
+		scrollYOnScrollDownStart: 0
 
 	# Add scroll listners
 	mounted: ->
@@ -77,14 +85,26 @@ export default
 			# Since we're fading to reveal, don't offset the transform
 			when @scrolledPast and @revealTransition == 'fade' then 0
 
-			# When scrolling down, shift off screen equally until scrolled past
-			else -1 * Math.min @height + @offset, @scrollY
+			# When scrolling down from top, shift off screen equally until scrolled past
+			when not @scrolledPast then -1 * @scrollY
+
+			# When detached and revealed, show
+			when @isDetached and @revealed then 0
+
+			# Else, hide
+			else -1 * @height
 
 		# Has the scroll moved past the header
 		scrolledPast: -> @scrollY > @height + @offset
 
 		# Fade in the header when we would show it after scrolling past it's height
-		revealed: -> @scrollingUp or not @scrolledPast
+		revealed: ->
+			# When scrolling up always show
+			return true if @scrollingUp
+			# When scrolling down and detached, wait closeOnScrollThreshold before hiding
+			return true if !@scrollingUp and @isDetached and (Math.abs(@scrollY - @scrollYOnScrollDownStart) < @closeOnScrollThreshold)
+			# When at top, show.  Else hide.
+			return !@scrolledPast
 
 		# At the top of of the page.
 		atScrollTop: ->
@@ -136,18 +156,24 @@ export default
 		# Figure out scroll direction
 		scrollY: (now, old) -> @scrollingUp = now != 0 and now < old
 
-		# Don't allow tweening of the header until the first scroll up. This is
-		# done to prevent a tween happening when the user first scrolls past the
-		# header height
-		scrollingUp: -> @isDetached = true if @scrollingUp and @scrolledPast
+		scrollingUp: ->
+			# Don't allow tweening of the header until the first scroll up. This is
+			# done to prevent a tween happening when the user first scrolls past the
+			# header height
+			@isDetached = true if @scrollingUp and @scrolledPast
+			# When header is detached and we start scrolling down, save scrollY value
+			@scrollYOnScrollDownStart = @scrollY if @isDetached and !@scrollingUp
 
 		# Tween when forced and clear when no longer forced if already at the top
 		forceReveal: (bool) ->
 			if @forceReveal then @isDetached = true
 			else if @atScrollTop then @isDetached = false
 
-		# When the user returns to the top, reset the tweening
-		atScrollTop: -> @isDetached = false if @atScrollTop
+		atScrollTop: ->
+			# When the user returns to the top, reset the tweening
+			@isDetached = false if @atScrollTop
+			# Emit event so the parent can use atScrollTop for styles or logic
+			@$emit 'atScrollTop', @atScrollTop
 
 		# Disable the transition on top when switching between isDetached states.
 		# Normally we want to allow top tweens, like if a notification bar height

--- a/index.vue
+++ b/index.vue
@@ -85,7 +85,8 @@ export default
 			# Since we're fading to reveal, don't offset the transform
 			when @scrolledPast and @revealTransition == 'fade' then 0
 
-			# When scrolling down from top, shift off screen equally until scrolled past
+			# When scrolling down from top, shift off screen equally until scrolled
+			# past
 			when not @scrolledPast then -1 * @scrollY
 
 			# When detached and revealed, show
@@ -99,10 +100,13 @@ export default
 
 		# Fade in the header when we would show it after scrolling past it's height
 		revealed: ->
+
 			# When scrolling up always show
 			return true if @scrollingUp
-			# When scrolling down and detached, wait closeOnScrollThreshold before hiding
 			return true if !@scrollingUp and @isDetached and (Math.abs(@scrollY - @scrollYOnScrollDownStart) < @closeOnScrollThreshold)
+
+			# When scrolling down and detached, wait closeOnScrollThreshold before
+			# hiding
 			# When at top, show.  Else hide.
 			return !@scrolledPast
 
@@ -157,10 +161,12 @@ export default
 		scrollY: (now, old) -> @scrollingUp = now != 0 and now < old
 
 		scrollingUp: ->
+
 			# Don't allow tweening of the header until the first scroll up. This is
 			# done to prevent a tween happening when the user first scrolls past the
 			# header height
 			@isDetached = true if @scrollingUp and @scrolledPast
+
 			# When header is detached and we start scrolling down, save scrollY value
 			@scrollYOnScrollDownStart = @scrollY if @isDetached and !@scrollingUp
 
@@ -170,8 +176,10 @@ export default
 			else if @atScrollTop then @isDetached = false
 
 		atScrollTop: ->
+
 			# When the user returns to the top, reset the tweening
 			@isDetached = false if @atScrollTop
+
 			# Emit event so the parent can use atScrollTop for styles or logic
 			@$emit 'atScrollTop', @atScrollTop
 


### PR DESCRIPTION
Two changes:

## Add "closeOnScrollThreshold" prop

When the bar is detached and revealed, this is the distance you must scroll down to hide the bar.  Larger values help prevent the user from accidentally hiding the bar when interacting with subnavs.  I've set the prop's default value to 0, so the package behavior remains exactly the same.

This came about because currently `detachable-header` hides itself when you start scrolling down, even 1px.  On my current project I have a big subnav and I found myself accidentally hiding the nav bar while interacting with the subnav.  `closeOnScrollThreshold` seems like a good solution.

## Emit "atScrollTop" event

I think it would be useful for `detachable-header` to emit its `atScrollTop` boolean value, in case you want to hook into it to make your header look different when it's at the top, eg. bigger logo, different background etc.