### PR TITLE
Add off-screen-pad

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ Vue.component('detachable-header', DetachableHeader)
 | `force-background` | `false` | Forces `show-background` class. |
 | `force-reveal` | `false` | Forces reveal of detached state. |
 | `scroll` | `undefined` | Manually pass in the current scroll value. This could be useful when used with a smooth scrolling library. |
+| `off-screen-pad` | `0` | Adds additional padding to the offscreen height to account for headers that may have overflow on the lower edge |

--- a/index.css
+++ b/index.css
@@ -1,4 +1,4 @@
-.detachable-header[data-v-6de5ab34] {
+.detachable-header[data-v-574fd4a6] {
   position: fixed;
   width: 100%;
   z-index: 10;
@@ -7,13 +7,13 @@
   transition-property: background, top;
   transition-duration: 0.2s;
 }
-.detachable-header.disable-top-tween[data-v-6de5ab34] {
+.detachable-header.disable-top-tween[data-v-574fd4a6] {
   transition-property: background;
 }
-.tween-reveal.reveal-translate[data-v-6de5ab34] {
+.tween-reveal.reveal-translate[data-v-574fd4a6] {
   transition-property: transform, background, top;
 }
-.tween-reveal.reveal-fade[data-v-6de5ab34] {
+.tween-reveal.reveal-fade[data-v-574fd4a6] {
   transition-property: opacity, background, top;
 }
 

--- a/index.js
+++ b/index.js
@@ -96,8 +96,8 @@ module.exports =
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var _node_modules_mini_css_extract_plugin_dist_loader_js_node_modules_css_loader_dist_cjs_js_node_modules_vue_loader_lib_loaders_stylePostLoader_js_node_modules_stylus_loader_index_js_node_modules_vue_loader_lib_index_js_vue_loader_options_index_vue_vue_type_style_index_0_id_6de5ab34_lang_stylus_scoped_true___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
-/* harmony import */ var _node_modules_mini_css_extract_plugin_dist_loader_js_node_modules_css_loader_dist_cjs_js_node_modules_vue_loader_lib_loaders_stylePostLoader_js_node_modules_stylus_loader_index_js_node_modules_vue_loader_lib_index_js_vue_loader_options_index_vue_vue_type_style_index_0_id_6de5ab34_lang_stylus_scoped_true___WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_node_modules_mini_css_extract_plugin_dist_loader_js_node_modules_css_loader_dist_cjs_js_node_modules_vue_loader_lib_loaders_stylePostLoader_js_node_modules_stylus_loader_index_js_node_modules_vue_loader_lib_index_js_vue_loader_options_index_vue_vue_type_style_index_0_id_6de5ab34_lang_stylus_scoped_true___WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _node_modules_mini_css_extract_plugin_dist_loader_js_node_modules_css_loader_dist_cjs_js_node_modules_vue_loader_lib_loaders_stylePostLoader_js_node_modules_stylus_loader_index_js_node_modules_vue_loader_lib_index_js_vue_loader_options_index_vue_vue_type_style_index_0_id_574fd4a6_prod_lang_stylus_scoped_true___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
+/* harmony import */ var _node_modules_mini_css_extract_plugin_dist_loader_js_node_modules_css_loader_dist_cjs_js_node_modules_vue_loader_lib_loaders_stylePostLoader_js_node_modules_stylus_loader_index_js_node_modules_vue_loader_lib_index_js_vue_loader_options_index_vue_vue_type_style_index_0_id_574fd4a6_prod_lang_stylus_scoped_true___WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_node_modules_mini_css_extract_plugin_dist_loader_js_node_modules_css_loader_dist_cjs_js_node_modules_vue_loader_lib_loaders_stylePostLoader_js_node_modules_stylus_loader_index_js_node_modules_vue_loader_lib_index_js_vue_loader_options_index_vue_vue_type_style_index_0_id_574fd4a6_prod_lang_stylus_scoped_true___WEBPACK_IMPORTED_MODULE_0__);
 /* unused harmony reexport * */
 
 
@@ -109,11 +109,10 @@ module.exports =
 // ESM COMPAT FLAG
 __webpack_require__.r(__webpack_exports__);
 
-// CONCATENATED MODULE: ./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/pug-plain-loader!./node_modules/vue-loader/lib??vue-loader-options!./index.vue?vue&type=template&id=6de5ab34&scoped=true&lang=pug&
-var render = function () {
-  var _vm = this
-  var _h = _vm.$createElement
-  var _c = _vm._self._c || _h
+// CONCATENATED MODULE: ./node_modules/vue-loader/lib/loaders/templateLoader.js??ref--5!./node_modules/pug-plain-loader!./node_modules/vue-loader/lib??vue-loader-options!./index.vue?vue&type=template&id=574fd4a6&scoped=true&lang=pug&
+var render = function render() {
+  var _vm = this,
+    _c = _vm._self._c
   return _c(
     "div",
     { staticClass: "detachable-header", class: _vm.classes, style: _vm.styles },
@@ -125,7 +124,7 @@ var staticRenderFns = []
 render._withStripped = true
 
 
-// CONCATENATED MODULE: ./index.vue?vue&type=template&id=6de5ab34&scoped=true&lang=pug&
+// CONCATENATED MODULE: ./index.vue?vue&type=template&id=574fd4a6&scoped=true&lang=pug&
 
 // CONCATENATED MODULE: ./node_modules/babel-loader/lib!./node_modules/coffee-loader!./node_modules/vue-loader/lib??vue-loader-options!./index.vue?vue&type=script&lang=coffee&
 /* harmony default export */ var lib_vue_loader_options_indexvue_type_script_lang_coffee_ = ({
@@ -161,6 +160,10 @@ render._withStripped = true
     // scroll down to hide the bar.  Larger values help prevent the user from
     // accidentally hiding the bar when interacting with subnavs.
     closeOnScrollThreshold: {
+      type: Number,
+      default: 0
+    },
+    offScreenPad: {
       type: Number,
       default: 0
     }
@@ -224,7 +227,7 @@ render._withStripped = true
 
         default:
           // Else, hide
-          return -1 * this.height;
+          return -1 * this.height - this.offScreenPad;
       }
     },
     // Has the scroll moved past the header
@@ -365,8 +368,8 @@ render._withStripped = true
 });
 // CONCATENATED MODULE: ./index.vue?vue&type=script&lang=coffee&
  /* harmony default export */ var indexvue_type_script_lang_coffee_ = (lib_vue_loader_options_indexvue_type_script_lang_coffee_); 
-// EXTERNAL MODULE: ./index.vue?vue&type=style&index=0&id=6de5ab34&lang=stylus&scoped=true&
-var indexvue_type_style_index_0_id_6de5ab34_lang_stylus_scoped_true_ = __webpack_require__(1);
+// EXTERNAL MODULE: ./index.vue?vue&type=style&index=0&id=574fd4a6&prod&lang=stylus&scoped=true&
+var indexvue_type_style_index_0_id_574fd4a6_prod_lang_stylus_scoped_true_ = __webpack_require__(1);
 
 // CONCATENATED MODULE: ./node_modules/vue-loader/lib/runtime/componentNormalizer.js
 /* globals __VUE_SSR_CONTEXT__ */
@@ -375,20 +378,19 @@ var indexvue_type_style_index_0_id_6de5ab34_lang_stylus_scoped_true_ = __webpack
 // This module is a runtime utility for cleaner component module output and will
 // be included in the final webpack user bundle.
 
-function normalizeComponent (
+function normalizeComponent(
   scriptExports,
   render,
   staticRenderFns,
   functionalTemplate,
   injectStyles,
   scopeId,
-  moduleIdentifier, /* server only */
+  moduleIdentifier /* server only */,
   shadowMode /* vue-cli only */
 ) {
   // Vue.extend constructor export interop
-  var options = typeof scriptExports === 'function'
-    ? scriptExports.options
-    : scriptExports
+  var options =
+    typeof scriptExports === 'function' ? scriptExports.options : scriptExports
 
   // render functions
   if (render) {
@@ -408,7 +410,8 @@ function normalizeComponent (
   }
 
   var hook
-  if (moduleIdentifier) { // server build
+  if (moduleIdentifier) {
+    // server build
     hook = function (context) {
       // 2.3 injection
       context =
@@ -434,11 +437,11 @@ function normalizeComponent (
   } else if (injectStyles) {
     hook = shadowMode
       ? function () {
-        injectStyles.call(
-          this,
-          (options.functional ? this.parent : this).$root.$options.shadowRoot
-        )
-      }
+          injectStyles.call(
+            this,
+            (options.functional ? this.parent : this).$root.$options.shadowRoot
+          )
+        }
       : injectStyles
   }
 
@@ -449,16 +452,14 @@ function normalizeComponent (
       options._injectStyles = hook
       // register for functional component in vue file
       var originalRender = options.render
-      options.render = function renderWithStyleInjection (h, context) {
+      options.render = function renderWithStyleInjection(h, context) {
         hook.call(context)
         return originalRender(h, context)
       }
     } else {
       // inject component registration as beforeCreate hook
       var existing = options.beforeCreate
-      options.beforeCreate = existing
-        ? [].concat(existing, hook)
-        : [hook]
+      options.beforeCreate = existing ? [].concat(existing, hook) : [hook]
     }
   }
 
@@ -483,14 +484,11 @@ var component = normalizeComponent(
   staticRenderFns,
   false,
   null,
-  "6de5ab34",
+  "574fd4a6",
   null
   
 )
 
-/* hot reload */
-if (false) { var api; }
-component.options.__file = "index.vue"
 /* harmony default export */ var index = __webpack_exports__["default"] = (component.exports);
 
 /***/ })

--- a/index.vue
+++ b/index.vue
@@ -51,9 +51,9 @@ export default
 			default: 0
 
 
-		offScreenPad:
+		offscreenHeight:
 			type: Number
-			default: 0
+			default: -> @height
 
 	data: ->
 		scrollingUp: false
@@ -98,7 +98,7 @@ export default
 			when @isDetached and @revealed then 0
 
 			# Else, hide
-			else (-1 * @height) - @offScreenPad
+			else -1 * @offscreenHeight
 
 		# Has the scroll moved past the header
 		scrolledPast: -> @scrollY > @height + @offset

--- a/index.vue
+++ b/index.vue
@@ -50,6 +50,11 @@ export default
 			type: Number
 			default: 0
 
+
+		offScreenPad:
+			type: Number
+			default: 0
+
 	data: ->
 		scrollingUp: false
 		windowScroll: 0
@@ -93,7 +98,7 @@ export default
 			when @isDetached and @revealed then 0
 
 			# Else, hide
-			else -1 * @height
+			else (-1 * @height) - @offScreenPad
 
 		# Has the scroll moved past the header
 		scrolledPast: -> @scrollY > @height + @offset


### PR DESCRIPTION
@weotch on the new buk site there's a CTA that sticks out below the edge of the typical header, adjusting the height of the header changes the dim of the whole background and makes it cover the CTA.

This PR adds in a new prop for `off-screen-pad` that defaults to 0, all it does is add a bit of height when the header is offscreen, allowing it to be completely hidden on Buk.

I'm not 100% on the name of the prop, let me know your thoughts.